### PR TITLE
Consume RabbitMQ messages in own thread

### DIFF
--- a/src/main/scala/com/stratio/receiver/RabbitMQInputDStream.scala
+++ b/src/main/scala/com/stratio/receiver/RabbitMQInputDStream.scala
@@ -63,7 +63,12 @@ class RabbitMQReceiver(params: Map[String, String], storageLevel: StorageLevel)
   def onStart() {
     implicit val akkaSystem = akka.actor.ActorSystem()
     getConnectionAndChannel match {
-      case Success((connection: Connection, channel: Channel)) => log.info("onStart, Connecting.."); receive(connection, channel)
+      case Success((connection: Connection, channel: Channel)) => log.info("onStart, Connecting..")
+        new Thread() {
+          override def run() {
+            receive(connection, channel)
+          }
+        }.start()
       case Failure(f) => log.error("Could not connect"); restart("Could not connect", f)
     }
   }


### PR DESCRIPTION
If the receive method is not called in an own thread, the onStart method is never left. 

As soon as an error occurs and the receiver is restarted in the finally block, it will lead to infinite restarting of the receiver, as the receiver gets never properly started.

The example also suggest it that way... http://spark.apache.org/docs/latest/streaming-custom-receivers.html